### PR TITLE
Changed textarea to text for the field asking for piName

### DIFF
--- a/src/composer/schemas/quotaRequest.json
+++ b/src/composer/schemas/quotaRequest.json
@@ -142,7 +142,7 @@
    },
 
       "piName":{
-         "type":"textarea",
+         "type":"text",
          "label": "Who is the PI for this project?",
          "name": "piName",
          "required": true


### PR DESCRIPTION
The field "Who is the PI for this project?" has been changed to text field instead of textarea
